### PR TITLE
Use dependencies sources first

### DIFF
--- a/techs/sources.js
+++ b/techs/sources.js
@@ -73,12 +73,12 @@ module.exports = inherit(require('enb/lib/tech/base-tech'), {
                             enbDependencies = enbDependencies.concat(profile.dependencies);
                         }
                     }
-                    sources = sources.concat(enbSources.map(function (sourceName) {
-                        return packageDir + '/' + sourceName;
-                    }));
                     enbDependencies.forEach(function (packageName) {
                         sources = sources.concat(readPackageSources(packagesDirectory + '/' + packageName));
                     });
+                    sources = sources.concat(enbSources.map(function (sourceName) {
+                        return packageDir + '/' + sourceName;
+                    }));
                 }
             }
             return sources;


### PR DESCRIPTION
Sometimes I want to override some libraries modules. So the orders of sources should be changed.

I use `enb-bevis-helper` in my project. Please publish the new version of it, too.
